### PR TITLE
feat(Intepreter): Add compile method

### DIFF
--- a/stencila/pyla/code_parsing.py
+++ b/stencila/pyla/code_parsing.py
@@ -8,17 +8,132 @@ import typing
 from stencila.schema.types import SoftwareSourceCode, Function, Variable, CodeError, CodeChunk, SchemaTypes, \
     BooleanSchema, StringSchema, IntegerSchema, NumberSchema, ArraySchema, TupleSchema, CodeExpression, Parameter
 
+ImportsType = typing.List[typing.Union[str, SoftwareSourceCode]]
+OptionalStringList = typing.Optional[typing.List[str]]
 
-class CodeChunkParseResult(typing.NamedTuple):
+
+class CodeChunkParseResult:
     """The result of parsing a `CodeChunk`."""
-    chunk_ast: typing.Optional[ast.Module] = None
-    imports: typing.List[typing.Union[str, SoftwareSourceCode]] = []
-    assigns: typing.List[str] = []
-    declares: typing.List[typing.Union[Function, Variable]] = []
-    alters: typing.List[str] = []
-    uses: typing.List[str] = []
-    reads: typing.List[str] = []
-    error: typing.Optional[CodeError] = None
+    chunk_ast: typing.Optional[ast.Module]
+    _imports: ImportsType
+    _assigns: typing.List[str]
+    _declares: typing.List[typing.Union[Function, Variable]]
+    _alters: typing.List[str]
+    _uses: typing.List[str]
+    _reads: typing.List[str]
+    error: typing.Optional[CodeError]
+
+    def __init__(self,
+                 chunk_ast: typing.Optional[ast.Module] = None,
+                 imports: typing.Optional[ImportsType] = None,
+                 assigns: OptionalStringList = None,
+                 declares: OptionalStringList = None,
+                 alters: OptionalStringList = None,
+                 uses: OptionalStringList = None,
+                 reads: OptionalStringList = None,
+                 error: typing.Optional[CodeError] = None):
+        self.chunk_ast = chunk_ast
+        self.imports = imports or []
+        self.assigns = assigns or []
+        self.declares = declares or []
+        self.alters = alters or []
+        self.uses = uses or []
+        self.reads = reads or []
+        self.error = error
+
+    def combined_code_imports(self, existing_imports: typing.Optional[ImportsType]) -> typing.Optional[ImportsType]:
+        """
+        Combine a list of existing imports (from a CodeChunk) with the parsed `imports`.
+
+        `self.imports` will be combined with `existing_imports`, with duplicates removed, unless `existing_imports` has
+        an empty string semaphore which indicates no new imports should be added.
+        """
+        if existing_imports is None:
+            return self.imports
+
+        if '' in existing_imports:
+            return existing_imports
+
+        imports = list(existing_imports)  # copy the list
+
+        for imp in self.imports:
+            if imp not in imports:
+                imports.append(imp)
+
+        return imports
+
+    @property
+    def imports(self) -> typing.Optional[ImportsType]:
+        if not self._imports:
+            return None
+
+        return self._imports
+
+    @imports.setter
+    def imports(self, imports: ImportsType) -> None:
+        self._imports = imports
+
+    @property
+    def assigns(self) -> OptionalStringList:
+        if not self._assigns:
+            return None
+        return self._assigns
+
+    @assigns.setter
+    def assigns(self, assigns: typing.List[str]) -> None:
+        self._assigns = assigns
+
+    @property
+    def declares(self) -> typing.Optional[typing.List[typing.Union[Function, Variable]]]:
+        if not self._declares:
+            return None
+        return self._declares
+
+    @declares.setter
+    def declares(self, declares: typing.List[typing.Union[Function, Variable]]) -> None:
+        self._declares = declares
+
+    @property
+    def alters(self) -> OptionalStringList:
+        if not self._alters:
+            return None
+        return self._alters
+
+    @alters.setter
+    def alters(self, alters: typing.List[str]) -> None:
+        self._alters = alters
+
+    @property
+    def uses(self) -> OptionalStringList:
+        if not self._uses:
+            return None
+        return self._uses
+
+    @uses.setter
+    def uses(self, uses: typing.List[str]) -> None:
+        self._uses = uses
+
+    @property
+    def reads(self) -> OptionalStringList:
+        if not self._reads:
+            return None
+        return self._reads
+
+    @reads.setter
+    def reads(self, reads: typing.List[str]) -> None:
+        self._reads = reads
+
+    def _asdict(self):
+        return {
+            'chunk_ast': self.chunk_ast,
+            'imports': self.imports,
+            'assigns': self.assigns,
+            'declares': self.declares,
+            'alters': self.alters,
+            'uses': self.uses,
+            'reads': self.reads,
+            'error': self.error
+        }
 
 
 class CodeChunkExecution(typing.NamedTuple):

--- a/stencila/pyla/code_parsing.py
+++ b/stencila/pyla/code_parsing.py
@@ -12,6 +12,7 @@ ImportsType = typing.List[typing.Union[str, SoftwareSourceCode]]
 OptionalStringList = typing.Optional[typing.List[str]]
 
 
+# pylint: disable=R0902
 class CodeChunkParseResult:
     """The result of parsing a `CodeChunk`."""
     chunk_ast: typing.Optional[ast.Module]
@@ -23,6 +24,7 @@ class CodeChunkParseResult:
     _reads: typing.List[str]
     error: typing.Optional[CodeError]
 
+    # pylint: disable=R0913
     def __init__(self,
                  chunk_ast: typing.Optional[ast.Module] = None,
                  imports: typing.Optional[ImportsType] = None,
@@ -48,7 +50,7 @@ class CodeChunkParseResult:
         `self.imports` will be combined with `existing_imports`, with duplicates removed, unless `existing_imports` has
         an empty string semaphore which indicates no new imports should be added.
         """
-        if existing_imports is None:
+        if existing_imports is None or self.imports is None:
             return self.imports
 
         if '' in existing_imports:
@@ -64,6 +66,7 @@ class CodeChunkParseResult:
 
     @property
     def imports(self) -> typing.Optional[ImportsType]:
+        """Get the `imports` list or `None` if the list is empty."""
         if not self._imports:
             return None
 
@@ -75,6 +78,7 @@ class CodeChunkParseResult:
 
     @property
     def assigns(self) -> OptionalStringList:
+        """Get the `assigns` list or `None` if the list is empty."""
         if not self._assigns:
             return None
         return self._assigns
@@ -85,6 +89,7 @@ class CodeChunkParseResult:
 
     @property
     def declares(self) -> typing.Optional[typing.List[typing.Union[Function, Variable]]]:
+        """Get the `declares` list or `None` if the list is empty."""
         if not self._declares:
             return None
         return self._declares
@@ -95,6 +100,7 @@ class CodeChunkParseResult:
 
     @property
     def alters(self) -> OptionalStringList:
+        """Get the `alters` list or `None` if the list is empty."""
         if not self._alters:
             return None
         return self._alters
@@ -105,6 +111,7 @@ class CodeChunkParseResult:
 
     @property
     def uses(self) -> OptionalStringList:
+        """Get the `uses` list or `None` if the list is empty."""
         if not self._uses:
             return None
         return self._uses
@@ -115,6 +122,7 @@ class CodeChunkParseResult:
 
     @property
     def reads(self) -> OptionalStringList:
+        """Get the `reads` list or `None` if the list is empty."""
         if not self._reads:
             return None
         return self._reads
@@ -124,6 +132,7 @@ class CodeChunkParseResult:
         self._reads = reads
 
     def _asdict(self):
+        """This method is to match the NamedTuple's built in method of the same name."""
         return {
             'chunk_ast': self.chunk_ast,
             'imports': self.imports,

--- a/stencila/pyla/errors.py
+++ b/stencila/pyla/errors.py
@@ -1,0 +1,14 @@
+"""Custom error classes"""
+
+class CapabilityError(Exception):
+    """
+    Custom error class to indicate that an executor is not capable of performing a method call.
+
+    Python implementation of Executa's
+    [CapabilityError](https://github.com/stencila/executa/blob/v1.4.0/src/base/errors.ts#L57).
+    Is translated to a JSON-RPC error with code `CapabilityError`.
+    """
+
+    def __init__(self, method: str, **kwargs):
+        params = ', '.join(['{} = {}'.format(name, value) for name, value in kwargs.items()])
+        super().__init__('Incapable of method "{}" with params "{}"'.format(method, params))

--- a/stencila/pyla/interpreter.py
+++ b/stencila/pyla/interpreter.py
@@ -291,13 +291,20 @@ class Interpreter:
         """Compile a `CodeChunk`"""
         if isinstance(node, CodeChunk) and Interpreter.is_python_code(node):
             chunk, parse_result = simple_code_chunk_parse(node)
-            if parse_result.imports: chunk.imports = parse_result.imports
-            if parse_result.assigns: chunk.assigns = parse_result.assigns
-            if parse_result.declares: chunk.declares = parse_result.declares
-            if parse_result.alters: chunk.alters = parse_result.alters
-            if parse_result.uses: chunk.uses = parse_result.uses
-            if parse_result.reads: chunk.reads = parse_result.reads
-            if parse_result.error: chunk.errors = parse_result.error
+            if parse_result.imports:
+                chunk.imports = parse_result.imports
+            if parse_result.assigns:
+                chunk.assigns = parse_result.assigns
+            if parse_result.declares:
+                chunk.declares = parse_result.declares
+            if parse_result.alters:
+                chunk.alters = parse_result.alters
+            if parse_result.uses:
+                chunk.uses = parse_result.uses
+            if parse_result.reads:
+                chunk.reads = parse_result.reads
+            if parse_result.error:
+                chunk.errors = parse_result.error
             return chunk
         raise CapabilityError('compile', node=node)
 

--- a/stencila/pyla/interpreter.py
+++ b/stencila/pyla/interpreter.py
@@ -328,7 +328,8 @@ class Interpreter:
         """Is a `CodeChunk` or `CodeExpression` Python code?"""
         return code.programmingLanguage.lower() in Interpreter.PROGRAMMING_LANGUAGES
 
-    def execute_code_expression(self, expression: CodeExpression, _locals: typing.Dict[str, typing.Any]) -> CodeExpression:
+    def execute_code_expression(self, expression: CodeExpression,
+                                _locals: typing.Dict[str, typing.Any]) -> CodeExpression:
         """Evaluate `CodeExpression.text`, and get the result. Catch any exception the occurs."""
         try:
             # pylint: disable=W0123  # Disable warning that eval is being used.
@@ -339,13 +340,14 @@ class Interpreter:
 
         return expression
 
-    def execute_code_chunk(self, chunk_execution: CodeChunkExecution, _locals: typing.Dict[str, typing.Any]) -> CodeChunk:
+    def execute_code_chunk(self, chunk_execution: CodeChunkExecution,
+                           _locals: typing.Dict[str, typing.Any]) -> CodeChunk:
         """Execute a `CodeChunk` that has been parsed and stored in a `CodeChunkExecution`."""
         chunk, parse_result = chunk_execution
 
         if parse_result.chunk_ast is None:
             LOGGER.info('Not executing CodeChunk without AST: %s', chunk.text[:CHUNK_PREVIEW_LENGTH])
-            return
+            return chunk
 
         cc_outputs: typing.List[typing.Any] = []
 

--- a/stencila/pyla/interpreter.py
+++ b/stencila/pyla/interpreter.py
@@ -260,6 +260,12 @@ class Interpreter:
 
     @staticmethod
     def compile_code_chunk(chunk: CodeChunk) -> typing.Tuple[CodeChunkParseResult, CodeChunk]:
+        """
+        Compile a `CodeChunk`.
+
+        Returns a `CodeChunkParseResult` which is primarily needed for the AST, and the `CodeChunk` itself, which has
+        its code metadata properties set.
+        """
         parser = CodeChunkParser()
         cc_result = parser.parse(chunk)
         chunk.imports = cc_result.combined_code_imports(chunk.imports)

--- a/stencila/pyla/interpreter.py
+++ b/stencila/pyla/interpreter.py
@@ -298,7 +298,7 @@ class Interpreter:
             cce = simple_code_chunk_parse(node)
             return self.execute_code_chunk(cce, _locals)
         if isinstance(node, CodeChunkExecution):
-            return self.execute_code_chunk(cce, _locals)
+            return self.execute_code_chunk(node, _locals)
         raise CapabilityError('execute', node=node)
 
     @staticmethod

--- a/stencila/pyla/interpreter.py
+++ b/stencila/pyla/interpreter.py
@@ -227,6 +227,51 @@ class DocumentCompiler:
 class Interpreter:
     """Execute a list of code blocks, maintaining its own `globals` scope for this execution run."""
 
+    """
+    JSON Schema specification of the types of nodes that `compile` and
+    `execute` methods are capable of handling
+    """
+    CODE_CAPABILITIES = {
+        'type': 'object',
+        'required': ['node'],
+        'properties': {
+            'node': {
+                'type': 'object',
+                'required': ['type', 'programmingLanguage'],
+                'properties': {
+                    'type': {
+                        'enum': ['CodeChunk', 'CodeExpression']
+                    },
+                    'programmingLanguage': {
+                        'enum': ['python', 'py']
+                    }
+                }
+            }
+        }
+    }
+
+    """
+    The manifest of this interpreters capabilities and addresses.
+
+    Conforms to Executa's
+    [Manifest](https://github.com/stencila/executa/blob/v1.4.0/src/base/Executor.ts#L63)
+    interface.
+    """
+    MANIFEST = {
+        'version': 1,
+        'capabilities': {
+            'compile': CODE_CAPABILITIES,
+            'execute': CODE_CAPABILITIES
+        },
+        'addresses': {
+            'stdio': {
+                'type': 'stdio',
+                'command': sys.executable,
+                'args': ['-m', 'stencila.pyla', 'serve']
+            }
+        }
+    }
+
     globals: typing.Dict[str, typing.Any]
     locals: typing.Dict[str, typing.Any]
 

--- a/stencila/pyla/interpreter.py
+++ b/stencila/pyla/interpreter.py
@@ -328,7 +328,7 @@ class Interpreter:
         """Is a `CodeChunk` or `CodeExpression` Python code?"""
         return code.programmingLanguage.lower() in Interpreter.PROGRAMMING_LANGUAGES
 
-    def execute_code_expression(self, expression: CodeExpression, _locals: typing.Dict[str, typing.Any]) -> None:
+    def execute_code_expression(self, expression: CodeExpression, _locals: typing.Dict[str, typing.Any]) -> CodeExpression:
         """Evaluate `CodeExpression.text`, and get the result. Catch any exception the occurs."""
         try:
             # pylint: disable=W0123  # Disable warning that eval is being used.
@@ -337,7 +337,9 @@ class Interpreter:
         except Exception as exc:
             set_code_error(expression, exc)
 
-    def execute_code_chunk(self, chunk_execution: CodeChunkExecution, _locals: typing.Dict[str, typing.Any]) -> None:
+        return expression
+
+    def execute_code_chunk(self, chunk_execution: CodeChunkExecution, _locals: typing.Dict[str, typing.Any]) -> CodeChunk:
         """Execute a `CodeChunk` that has been parsed and stored in a `CodeChunkExecution`."""
         chunk, parse_result = chunk_execution
 
@@ -372,6 +374,8 @@ class Interpreter:
                 cc_outputs[new_last_index] = self.decode_mpl()
 
         chunk.outputs = cc_outputs
+
+        return chunk
 
     def execute_statement(self, statement: ast.stmt, chunk: CodeChunk, _locals: typing.Dict[str, typing.Any],
                           cc_outputs: typing.List[str], duration: float) -> typing.Tuple[float, bool]:

--- a/stencila/pyla/servers.py
+++ b/stencila/pyla/servers.py
@@ -9,10 +9,10 @@ import json
 import logging
 import typing
 from socket import socket
-from stencila.schema.types import CodeChunk, Node
+from stencila.schema.types import Node
 from stencila.schema.util import from_dict, object_encode
 
-from .code_parsing import simple_code_chunk_parse
+from .errors import CapabilityError
 from .interpreter import Interpreter
 
 StreamType = typing.Union[typing.BinaryIO, socket]
@@ -215,16 +215,6 @@ class StreamServer:
         """Write a length-prefixed message to the output stream."""
         message_write(self.output_stream, message)
 
-    def execute_node(self, node: dict) -> Node:
-        """Parse a `CodeChunk` or `CodeExpression` from `node` and execute it with the `interpreter`."""
-        code = from_dict(node)
-        if isinstance(code, CodeChunk):
-            to_execute = simple_code_chunk_parse(code)
-        else:
-            to_execute = code
-        self.interpreter.execute([to_execute], {})
-        return code
-
     def receive_message(self, message: str) -> str:
         """
         Receive a JSON-RPC request and send back a JSON-RPC response.
@@ -250,15 +240,18 @@ class StreamServer:
 
             if method == 'manifest':
                 result = Interpreter.MANIFEST
-            elif method == 'execute':
+            elif method in ('compile', 'execute'):
                 node = params.get('node')
                 if node is None:
                     raise JsonRpcError(JsonRpcErrorCode.InvalidParams, 'Invalid params: "node" is missing')
-                result = self.execute_node(node)
+                node = from_dict(node)
+                result = self.interpreter.compile(node) if method == 'compile' else self.interpreter.execute(node)
             else:
                 raise JsonRpcError(JsonRpcErrorCode.MethodNotFound, 'Method not found: {}'.format(method))
         except JsonRpcError as exc:
             error = exc
+        except CapabilityError as exc:
+            error = JsonRpcError(JsonRpcErrorCode.CapabilityError, 'Capability error: {}'.format(exc))
         except Exception as exc:  # pylint: disable=broad-except
             logging.exception(exc)
             error = JsonRpcError(JsonRpcErrorCode.ServerError, 'Internal error: {}'.format(exc))

--- a/stencila/pyla/servers.py
+++ b/stencila/pyla/servers.py
@@ -249,18 +249,11 @@ class StreamServer:
             params = request.get('params')
 
             if method == 'manifest':
-                result = {
-                    # Temporary. Should return real manifest
-                    'capabilities': {
-                        'manifest': True,
-                        'execute': True
-                    }
-                }
+                result = Interpreter.MANIFEST
             elif method == 'execute':
                 node = params.get('node')
                 if node is None:
                     raise JsonRpcError(JsonRpcErrorCode.InvalidParams, 'Invalid params: "node" is missing')
-
                 result = self.execute_node(node)
             else:
                 raise JsonRpcError(JsonRpcErrorCode.MethodNotFound, 'Method not found: {}'.format(method))

--- a/stencila/pyla/system.py
+++ b/stencila/pyla/system.py
@@ -6,38 +6,10 @@ import os
 import sys
 import typing
 
+from .interpreter import Interpreter
+
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.NullHandler())
-
-MANIFEST = {
-    'capabilities': {
-        'execute': {
-            'type': 'object',
-            'required': ['node'],
-            'properties': {
-                'node': {
-                    'type': 'object',
-                    'required': ['type', 'programmingLanguage'],
-                    'properties': {
-                        'type': {
-                            'enum': ['CodeChunk', 'CodeExpression']
-                        },
-                        'programmingLanguage': {
-                            'enum': ['python']
-                        }
-                    }
-                }
-            }
-        }
-    },
-    'addresses': {
-        'stdio': {
-            'type': 'stdio',
-            'command': 'python3',
-            'args': ['-m', 'stencila.pyla', 'serve']
-        }
-    }
-}
 
 MANIFEST_FILE_NAME = 'pyla.json'
 EXECUTORS_DIR_NAME = 'executors'
@@ -97,10 +69,9 @@ class ManifestManager:
         provide compatibility with virtual environments. The means that if you re-run the register command with
         different python binaries a different manifest will be written out.
         """
-        MANIFEST['addresses']['stdio']['command'] = sys.executable  # type:ignore
         os.makedirs(self.manifest_dir(), exist_ok=True)
         with open(self.manifest_path(), 'w') as manifest_file:
-            json.dump(MANIFEST, manifest_file, indent=True)
+            json.dump(Interpreter.MANIFEST, manifest_file, indent=True)
         LOGGER.info('Manifest saved to \'%s\'', self.manifest_path())
 
     def deregister(self) -> None:

--- a/tests/test_document_compiler.py
+++ b/tests/test_document_compiler.py
@@ -137,3 +137,4 @@ def test_import_with_semaphore():
     assert 'modc' in c.imports
     assert 'modd' in c.imports
     assert '' in c.imports
+

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -8,28 +8,25 @@ from stencila.pyla.interpreter import Interpreter, execute_compilation, compile_
 
 def execute_code_chunk(text: str) -> CodeChunk:
     cc = CodeChunk(text)
-    cce = CodeChunkExecution(
-        cc, CodeChunkParser().parse(cc)
-    )
-    Interpreter().execute([cce], {})
+    Interpreter().execute(cc)
     return cc
 
 
 def test_execute_simple_code_expression():
     ce = CodeExpression('4 + 5')
-    Interpreter().execute([ce], {})
+    Interpreter().execute(ce)
     assert ce.output == 9
 
 
 def test_execute_parameterised_code_expression():
     ce = CodeExpression('p1 + p2')
-    Interpreter().execute([ce], {'p1': 1, 'p2': 10})
+    Interpreter().execute(ce, {'p1': 1, 'p2': 10})
     assert ce.output == 11
 
 
 def test_catch_code_expression_error():
     ce = CodeExpression('1 / 0')
-    Interpreter().execute([ce], {})
+    Interpreter().execute(ce)
     assert ce.output is None
     assert ce.errors[0].kind == 'ZeroDivisionError'
     assert ce.errors[0].message == 'division by zero'
@@ -76,14 +73,10 @@ def test_code_chunk_exception_capture():
     cc1 = CodeChunk('a = 5\na + 2\nprint(\'Goodbye world!\')\nbadref += 1\nprint(\'After exception!\')')
     cc2 = CodeChunk('2 + 2\nprint(\'CodeChunk2\')')
 
-    cce1 = CodeChunkExecution(
-        cc1, CodeChunkParser().parse(cc1)
-    )
-    cce2 = CodeChunkExecution(
-        cc2, CodeChunkParser().parse(cc2)
-    )
+    interpreter = Interpreter()
+    for cc in [cc1, cc2]:
+        interpreter.execute(cc)
 
-    Interpreter().execute([cce1, cce2], {})
     assert cc1.outputs == [7, 'Goodbye world!\n']
     assert cc1.errors[0].kind == 'NameError'
 
@@ -113,7 +106,7 @@ def test_execute_compilation(mock_interpreter_class, mock_pp_class):
 
     mock_pp_class.assert_called_with(compilation_result.parameters)
     parameter_parser.parse_cli_args.assert_called_with(parameters)
-    interpreter.execute.assert_called_with(compilation_result.code, parameter_parser.parameter_values)
+    interpreter.execute.assert_not_called() #Because nothing in compilation_result
 
 
 def test_sempahore_skipping():

--- a/tests/test_servers.py
+++ b/tests/test_servers.py
@@ -173,7 +173,7 @@ def test_receive_message_with_unknown_method():
 
 
 def test_receive_message_with_internal_server_error():
-    """Test that a JsonRpcError with code JsonRpcErrorCode.MethodNotFound if some other exception occurs"""
+    """Test that a JsonRpcError with code JsonRpcErrorCode.ServerError if some other exception occurs"""
     message = json.dumps({
         'id': 13,
         'method': 'execute',


### PR DESCRIPTION
- Exposes code parsing as the `compile` method on `Interpreter`, accessible via `Server`. This enables Executa to delegate the `compile` method to Pyla for Python code chunks.

- Moves manifest definition to interpreter and adds the `compile` capability.

- Does some refactoring so that `Server` does nothing but dispatch methods calls to `Interpreter` as in Executa itself.

With these changes, and [this PR](https://github.com/stencila/executa/pull/59) in Executa, you can do:

```bash
executa compile test.md - --to yaml
```

with `test.md`,

````md
# A test

chunk:
:::
```py
import time
from matplotlib import pyplot as plt
import pandas

with open('some-data.csv') as file:
  pass

```
:::
````

produces this,

```yaml
type: Article
authors: []
title: Untitled
content:
  - type: Heading
    depth: 1
    content:
      - A test
  - type: CodeChunk
    imports:
      - time
      - matplotlib
      - pandas
    programmingLanguage: py
    reads:
      - some-data.csv
    text: |
      import time
      from matplotlib import pyplot as plt
      import pandas

      with open('some-data.csv') as file:
        pass
```
