### PR TITLE
Resolve imported modules into packages

### DIFF
--- a/stencila/pyla/code_parsing.py
+++ b/stencila/pyla/code_parsing.py
@@ -67,6 +67,23 @@ class CodeChunkParseResult:
 
         return imports
 
+    def resolved_code_imports(self, existing_imports: typing.Optional[ImportsType]) -> typing.Optional[typing.List[SoftwareSourceCode]]:
+        """
+        Resolve the name of modules to packages.
+
+        In Python there is not a one-to-one between the name of the imported module
+        and the package / distribution it belongs to.
+        """
+        imports = self.combined_code_imports(existing_imports)
+        if not imports:
+            return None
+        
+        sscs = []
+        for name in imports:
+            # TODO: check that the import is not already a `SoftwareSourceCode`
+            sscs.append(SoftwareSourceCode(name=name, runtimePlatform='python'))
+        return sscs
+
     @property
     def imports(self) -> typing.Optional[ImportsType]:
         """Get the `imports` list or `None` if the list is empty."""

--- a/stencila/pyla/interpreter.py
+++ b/stencila/pyla/interpreter.py
@@ -268,7 +268,7 @@ class Interpreter:
         """
         parser = CodeChunkParser()
         cc_result = parser.parse(chunk)
-        chunk.imports = cc_result.combined_code_imports(chunk.imports)
+        chunk.imports = cc_result.resolved_code_imports(chunk.imports)
         chunk.declares = cc_result.declares
         chunk.assigns = cc_result.assigns
         chunk.alters = cc_result.alters


### PR DESCRIPTION
I quickly added a function that converts `string`s in `imports` into `SoftwareSourceCode` nodes. We need to do this in the long term when we want to pass Dockta or Nixta a big list of packages to create a image / environ from (potentially specifying `version`) etc.

With this Markdown doc:

````md
chunk:
:::
```py
import pandas
import matplotlib.figure
import matplotlib.artist
from matplotlib.cbook import silent_list
```
:::
````

Running `executa query temp.md - content` gives (which is kinda cool because in the background Executa, delegated to Pyla to compile that chunk):

```json5
  {
    type: 'CodeChunk',
    text: 'import pandas\nimport matplotlib.figure\nimport matplotlib.artist\nfrom matplotlib.cbook import silent_list',
    programmingLanguage: 'py',
    imports: [
      {
        type: 'SoftwareSourceCode',
        name: 'pandas',
        runtimePlatform: 'python',
      },
      {
        type: 'SoftwareSourceCode',
        name: 'matplotlib.figure',
        runtimePlatform: 'python',
      },
      {
        type: 'SoftwareSourceCode',
        name: 'matplotlib.artist',
        runtimePlatform: 'python',
      },
      {
        type: 'SoftwareSourceCode',
        name: 'matplotlib.cbook',
        runtimePlatform: 'python',
      },
    ],
    declares: null,
    assigns: null,
    alters: null,
    uses: null,
    reads: null,
  }
```

Anyway, clearly this isn't there yet because `matplotlib.figure` etc are not packages. Ideally the compiled document would be:

```json5
  {
    type: 'CodeChunk',
    text: 'import pandas\nimport matplotlib.figure\nimport matplotlib.artist\nfrom matplotlib.cbook import silent_list',
    programmingLanguage: 'py',
    imports: [
      {
        type: 'SoftwareSourceCode',
        name: 'pandas',
        runtimePlatform: 'python',
      },
      {
        type: 'SoftwareSourceCode',
        name: 'matplotlib',
        runtimePlatform: 'python',
      }
    ]
  }
```

I had a quick search and it looks like the following may be able to help us:

- https://docs.python.org/3/library/importlib.html#importlib.abc.MetaPathFinder.find_spec
- https://docs.python.org/3/library/importlib.metadata.html
- https://setuptools.readthedocs.io/en/latest/pkg_resources.html

@beneboy Would you be able to take this on? I can't remember how Dockta deals with the `module name != package name` issue.